### PR TITLE
Autopull game length from API

### DIFF
--- a/components/layout/GameForm.tsx
+++ b/components/layout/GameForm.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import GameLengthInput from "@/components/layout/GameLengthInput"
 import NintendoLinkInput from "@/components/layout/NintendoLinkInput"
 import PlayStationLinkInput from "@/components/layout/PlayStationLinkInput"
 import { Button } from "@/components/ui/button"
@@ -329,20 +330,10 @@ export default function GameForm({
         className="mt-5 duration-500 animate-in fade-in slide-in-from-top-3"
         style={{ animationDelay: "50ms", animationFillMode: "backwards" }}
       >
-        <label className="text-sm font-semibold" htmlFor="length">
-          Game Length
-        </label>
-        <p className="text-xs text-muted-foreground">
-          Enter the length in hours.
-        </p>
-        <Input
-          id="length"
-          type="number"
-          className="mt-2"
-          placeholder="e.g. 20"
-          min="0"
+        <GameLengthInput
+          igdbGameId={game?.igdbGameId}
           value={formData.length}
-          onChange={(e) => dispatch({ field: "length", value: e.target.value })}
+          onChange={(value) => dispatch({ field: "length", value })}
         />
       </div>
 

--- a/components/layout/GameForm.tsx
+++ b/components/layout/GameForm.tsx
@@ -341,7 +341,6 @@ export default function GameForm({
           <GameLengthInput
             igdbGameId={game?.igdbGameId}
             value={formData.length}
-            isEdit={isEdit}
             onChange={(value) => dispatch({ field: "length", value })}
           />
         )}

--- a/components/layout/GameForm.tsx
+++ b/components/layout/GameForm.tsx
@@ -70,6 +70,7 @@ export default function GameForm({
   )
   const [playstationInfo, setPlaystationInfo] = useState<GamePrice | null>(null)
   const [nowPlaying, setNowPlaying] = useState(false)
+  const [isDataLoaded, setIsDataLoaded] = useState(false)
 
   const platformReducer = (
     state: PlatformState,
@@ -179,6 +180,12 @@ export default function GameForm({
         // The user can fetch prices later if they want
         // Store URLs are just for display/reference
       }
+
+      // Mark data as loaded after all setup is complete
+      setIsDataLoaded(true)
+    } else {
+      // For new games (not editing), mark as loaded immediately
+      setIsDataLoaded(true)
     }
   }, [game, isFromIGDB])
 
@@ -330,11 +337,14 @@ export default function GameForm({
         className="mt-5 duration-500 animate-in fade-in slide-in-from-top-3"
         style={{ animationDelay: "50ms", animationFillMode: "backwards" }}
       >
-        <GameLengthInput
-          igdbGameId={game?.igdbGameId}
-          value={formData.length}
-          onChange={(value) => dispatch({ field: "length", value })}
-        />
+        {(!isEdit || isDataLoaded) && (
+          <GameLengthInput
+            igdbGameId={game?.igdbGameId}
+            value={formData.length}
+            isEdit={isEdit}
+            onChange={(value) => dispatch({ field: "length", value })}
+          />
+        )}
       </div>
 
       <div
@@ -450,7 +460,7 @@ export default function GameForm({
             Owned on
           </label>
           <p className="text-xs text-muted-foreground">
-            Select all platforms you own this on.
+            Select all platforms you own the game on.
           </p>
           <div
             className={clsx(

--- a/components/layout/GameLengthInput.tsx
+++ b/components/layout/GameLengthInput.tsx
@@ -1,0 +1,150 @@
+"use client"
+
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { fetchGameTimeToBeats } from "@/server/actions/igdb"
+import { useEffect, useState } from "react"
+import Spinner from "../ui/spinner"
+
+interface GameLengthInputProps {
+  igdbGameId?: string
+  value: string
+  onChange: (value: string) => void
+}
+
+type State = "loading" | "input" | "fetched"
+
+export default function GameLengthInput({
+  igdbGameId,
+  value,
+  onChange
+}: GameLengthInputProps) {
+  const [state, setState] = useState<State>("loading")
+
+  useEffect(() => {
+    const init = async () => {
+      if (value || !igdbGameId) {
+        setState("input")
+        return
+      }
+
+      try {
+        const timeData = await fetchGameTimeToBeats(igdbGameId)
+        if (timeData?.normallyHours) {
+          onChange(timeData.normallyHours.toString())
+          setState("fetched")
+          return
+        }
+      } catch (error) {
+        console.error("Error fetching game time to beat:", error)
+      }
+
+      setState("input")
+    }
+
+    init()
+  }, [])
+
+  return (
+    <>
+      <label className="text-sm font-semibold" htmlFor="length">
+        Game Length
+      </label>
+      {state === "loading" && loadingState()}
+      {state === "fetched" && fetchedState(value)}
+      {state === "input" && inputState(value, onChange)}
+    </>
+  )
+}
+
+const loadingState = () => {
+  return (
+    <div className="mt-2 flex min-h-10 items-center justify-center">
+      <Spinner size={32} className="my-0" />
+    </div>
+  )
+}
+
+const fetchedState = (value: string) => {
+  return (
+    <p className="mt-2 text-sm text-gray-700">
+      The game takes around
+      <span className="font-semibold"> {value} hours</span>.
+    </p>
+  )
+}
+
+const inputState = (value: string, onChange: (value: string) => void) => {
+  const handleIncrement = (amount: number) => {
+    const currentValue = parseInt(value) || 0
+    const newValue = Math.max(0, Math.min(9999, currentValue + amount))
+    onChange(newValue.toString())
+  }
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const inputValue = e.target.value
+    if (inputValue === "") {
+      onChange("")
+    } else {
+      const numValue = parseInt(inputValue)
+      if (!isNaN(numValue) && numValue >= 0 && numValue <= 9999) {
+        onChange(numValue.toString())
+      }
+    }
+  }
+
+  return (
+    <>
+      <p className="text-xs text-muted-foreground">
+        Enter the length in hours.
+      </p>
+      <div className="mt-2 flex items-center gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => handleIncrement(-10)}
+          className="min-h-10 flex-1"
+        >
+          -10
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => handleIncrement(-1)}
+          className="min-h-10 flex-1"
+        >
+          -1
+        </Button>
+        <Input
+          type="number"
+          placeholder="0"
+          min="0"
+          max="9999"
+          value={value}
+          onChange={handleInputChange}
+          className="flex-[2] text-center"
+        />
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => handleIncrement(1)}
+          className="min-h-10 flex-1"
+        >
+          +1
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => handleIncrement(10)}
+          className="min-h-10 flex-1"
+        >
+          +10
+        </Button>
+      </div>
+    </>
+  )
+}

--- a/components/layout/GameLengthInput.tsx
+++ b/components/layout/GameLengthInput.tsx
@@ -9,7 +9,6 @@ import Spinner from "../ui/spinner"
 interface GameLengthInputProps {
   igdbGameId?: string
   value: string
-  isEdit?: boolean
   onChange: (value: string) => void
 }
 
@@ -18,7 +17,6 @@ type State = "loading" | "input" | "fetched"
 export default function GameLengthInput({
   igdbGameId,
   value,
-  isEdit,
   onChange
 }: GameLengthInputProps) {
   const [state, setState] = useState<State>("loading")
@@ -27,9 +25,6 @@ export default function GameLengthInput({
   useEffect(() => {
     let cancelled = false
     const init = async () => {
-      console.log("value :>>", value)
-      console.log("igdbGameId :>>", igdbGameId)
-
       if (hasFetched) {
         setState("fetched")
         return


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Game length field can auto-fetch estimated playtime and pre-fill when available.
  * Compact numeric controls (±1, ±10) and validated numeric input added for adjusting game length.
  * Shows a loading state while fetching estimates; input appears once data is ready.

* **Bug Fixes**
  * Platform ownership text clarified to "Select all platforms you own the game on."

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->