### PR TITLE
Search history suggestions

### DIFF
--- a/components/game/SearchBar.tsx
+++ b/components/game/SearchBar.tsx
@@ -1,10 +1,17 @@
 "use client"
 
 import { encodePathSegment } from "@/lib/path"
-import { Search, X } from "lucide-react"
-import { Input } from "../ui/input"
+import {
+  deleteSearchQuery,
+  getSearchQueries,
+  saveSearchQuery
+} from "@/server/actions/search"
+import { History, Search, X } from "lucide-react"
 import { useEffect, useRef, useState } from "react"
 import { useRouter } from "../navigation"
+import { Input } from "../ui/input"
+import { Popover, PopoverAnchor, PopoverContent } from "../ui/popover"
+import { Button } from "../ui/button"
 
 interface Props {
   initialQuery?: string
@@ -12,8 +19,14 @@ interface Props {
 
 export function SearchBar({ initialQuery = "" }: Props) {
   const router = useRouter()
+  const [open, setOpen] = useState(false)
   const [query, setQuery] = useState(initialQuery)
+  const [history, setHistory] = useState<string[]>([])
   const inputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    getSearchQueries().then((queries) => setHistory(queries))
+  }, [])
 
   useEffect(() => {
     setQuery(initialQuery)
@@ -35,8 +48,14 @@ export function SearchBar({ initialQuery = "" }: Props) {
     e.preventDefault()
     inputRef.current?.blur()
     const trimmedQuery = query.trim()
+    if (!trimmedQuery) return
 
     router.push(`/search/${encodePathSegment(trimmedQuery)}`)
+
+    setHistory((prev) =>
+      [trimmedQuery, ...prev.filter((q) => q !== trimmedQuery)].slice(0, 5)
+    )
+    saveSearchQuery(trimmedQuery)
   }
 
   const handleClearSearch = () => {
@@ -45,38 +64,84 @@ export function SearchBar({ initialQuery = "" }: Props) {
     inputRef.current?.focus()
   }
 
+  const handleQueryClick = (keyword: string) => {
+    inputRef.current?.blur()
+    router.push(`/search/${encodePathSegment(keyword.trim())}`)
+    setHistory((prev) =>
+      [keyword, ...prev.filter((q) => q !== keyword)].slice(0, 5)
+    )
+    saveSearchQuery(keyword)
+  }
+
+  const handleSearchQueryDelete = (keyword: string) => {
+    setHistory((prev) => prev.filter((q) => q !== keyword))
+    deleteSearchQuery(keyword)
+  }
+
   return (
-    <form onSubmit={handleSubmit} className="relative w-full">
-      <Search
-        className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-muted-foreground"
-        aria-hidden
-        size={18}
-      />
+    <Popover open={open && history.length > 0}>
+      <PopoverAnchor asChild>
+        <form onSubmit={handleSubmit} className="relative w-full">
+          <Search
+            className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-muted-foreground"
+            aria-hidden
+            size={18}
+          />
 
-      <Input
-        ref={inputRef}
-        type="text"
-        inputMode="search"
-        autoComplete="off"
-        autoCorrect="off"
-        autoCapitalize="off"
-        spellCheck="false"
-        value={query}
-        onChange={(e) => setQuery(e.target.value)}
-        placeholder="Search for games..."
-        className="pl-11 pr-12 transition-all duration-200"
-      />
+          <Input
+            ref={inputRef}
+            type="text"
+            inputMode="search"
+            autoComplete="off"
+            autoCorrect="off"
+            autoCapitalize="off"
+            spellCheck="false"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onFocus={() => setOpen(true)}
+            onBlur={() => setOpen(false)}
+            placeholder="Search for games..."
+            className="pl-11 pr-12 transition-all duration-200"
+          />
 
-      {query && (
-        <button
-          type="button"
-          onClick={handleClearSearch}
-          className="absolute right-0 top-1/2 -translate-y-1/2 p-4 text-muted-foreground hover:text-muted-foreground/80"
-          aria-label="Clear search"
-        >
-          <X size={18} />
-        </button>
-      )}
-    </form>
+          {query && (
+            <button
+              type="button"
+              onClick={handleClearSearch}
+              className="absolute right-0 top-1/2 -translate-y-1/2 p-4 text-muted-foreground hover:text-muted-foreground/80"
+              aria-label="Clear search"
+            >
+              <X size={18} />
+            </button>
+          )}
+        </form>
+      </PopoverAnchor>
+      <PopoverContent
+        className="z-40 mt-2 px-0 py-[2px]"
+        onMouseDown={(e) => e.preventDefault()}
+        onOpenAutoFocus={(e) => e.preventDefault()}
+      >
+        {history.map((keyword) => (
+          <div
+            className="flex cursor-pointer items-center gap-2 border-b py-2 pl-5 pr-2 text-sm last:border-none"
+            onClick={() => handleQueryClick(keyword)}
+            key={keyword}
+          >
+            <History className="size-[15px] text-muted-foreground" />
+            <span className="line-clamp-1 flex-1">{query}</span>
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={(e) => {
+                e.stopPropagation()
+                handleSearchQueryDelete(keyword)
+              }}
+            >
+              <X className="size-4 text-muted-foreground" />
+            </Button>
+          </div>
+        ))}
+      </PopoverContent>
+    </Popover>
   )
 }

--- a/components/game/SearchBar.tsx
+++ b/components/game/SearchBar.tsx
@@ -128,7 +128,7 @@ export function SearchBar({ initialQuery = "" }: Props) {
             key={keyword}
           >
             <History className="size-[15px] text-muted-foreground" />
-            <span className="line-clamp-1 flex-1">{query}</span>
+            <span className="line-clamp-1 flex-1">{keyword}</span>
             <Button
               size="sm"
               variant="ghost"

--- a/components/ui/popover.tsx
+++ b/components/ui/popover.tsx
@@ -9,6 +9,8 @@ const Popover = PopoverPrimitive.Root
 
 const PopoverTrigger = PopoverPrimitive.Trigger
 
+const PopoverAnchor = PopoverPrimitive.Anchor
+
 const PopoverContent = React.forwardRef<
   React.ElementRef<typeof PopoverPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
@@ -40,4 +42,4 @@ const PopoverContent = React.forwardRef<
 )
 PopoverContent.displayName = PopoverPrimitive.Content.displayName
 
-export { Popover, PopoverTrigger, PopoverContent }
+export { Popover, PopoverTrigger, PopoverAnchor, PopoverContent }

--- a/server/actions/search.ts
+++ b/server/actions/search.ts
@@ -1,0 +1,52 @@
+"use server"
+
+import { authOptions } from "@/lib/auth-options"
+import { getServerSession } from "next-auth"
+import prisma from "@/lib/prisma"
+
+export async function getSearchQueries(): Promise<string[]> {
+  const session = await getServerSession(authOptions)
+  const userId = session?.user?.id
+  if (!userId) return []
+
+  const results = await prisma.searchHistory.findMany({
+    where: { userId },
+    orderBy: { searchedAt: "desc" },
+    take: 5,
+    select: { query: true }
+  })
+
+  return results.map((r) => r.query)
+}
+
+export async function saveSearchQuery(query: string) {
+  const trimmed = query.trim()
+  if (!trimmed) return
+
+  const session = await getServerSession(authOptions)
+  const userId = session?.user?.id
+  if (!userId) return
+
+  await prisma.searchHistory.upsert({
+    where: { userId_query: { userId, query: trimmed } },
+    create: { userId, query: trimmed },
+    update: { searchedAt: new Date() }
+  })
+}
+
+export async function deleteSearchQuery(query: string) {
+  const trimmed = query.trim()
+  if (!trimmed) return
+
+  const session = await getServerSession(authOptions)
+  const userId = session?.user?.id
+  if (!userId) return
+
+  await prisma.searchHistory.deleteMany({
+    where: {
+      // userId_query: { userId, query: trimmed }
+      query: trimmed,
+      userId
+    }
+  })
+}

--- a/server/prisma/migrations/20260225195042_add_search_history/migration.sql
+++ b/server/prisma/migrations/20260225195042_add_search_history/migration.sql
@@ -1,0 +1,18 @@
+-- CreateTable
+CREATE TABLE "SearchHistory" (
+    "id" TEXT NOT NULL,
+    "query" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "searchedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "SearchHistory_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "SearchHistory_userId_searchedAt_idx" ON "SearchHistory"("userId", "searchedAt" DESC);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "SearchHistory_userId_query_key" ON "SearchHistory"("userId", "query");
+
+-- AddForeignKey
+ALTER TABLE "SearchHistory" ADD CONSTRAINT "SearchHistory_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -53,6 +53,7 @@ model User {
   accounts      Account[]
   sessions      Session[]
   games         Game[]
+  searchHistory SearchHistory[]
 }
 
 model VerificationToken {
@@ -149,4 +150,15 @@ model Price {
   trackedBy     Game[]   @relation("TrackedPrices")
 
   @@index([platform, externalId])
+}
+
+model SearchHistory {
+  id         String   @id @default(cuid())
+  query      String
+  userId     String
+  user       User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  searchedAt DateTime @default(now())
+
+  @@unique([userId, query])
+  @@index([userId, searchedAt(sort: Desc)])
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Added server-side search history actions: getSearchQueries(), saveSearchQuery(), deleteSearchQuery()
- Extended SearchBar component with local history state, popover-based UI, handlers to load/display/select/delete queries, and persistence integration
- Introduced SearchHistory Prisma model (unique userId+query, index on userId,searchedAt desc) and added relation to User with cascade delete
- Added migration SQL to create SearchHistory table with indexes and foreign key constraints
- Exported PopoverAnchor from components/ui/popover.tsx to support the popover UI
<!-- end of auto-generated comment: release notes by coderabbit.ai -->