### PR TITLE
Steam reviews scafolding

### DIFF
--- a/server/actions/reviews.ts
+++ b/server/actions/reviews.ts
@@ -36,7 +36,7 @@ async function fetchSteamReviews(steamId: string): Promise<SteamReviews> {
   const total = data?.query_summary?.total_reviews
   const description = data?.query_summary?.review_score_desc
 
-  if (total == null && !description) throw new Error("No Reviews")
+  if (total == null || !description) throw new Error("No Reviews")
 
   return {
     total,

--- a/server/actions/reviews.ts
+++ b/server/actions/reviews.ts
@@ -36,7 +36,7 @@ async function fetchSteamReviews(steamId: string): Promise<SteamReviews> {
   const total = data?.query_summary?.total_reviews
   const description = data?.query_summary?.review_score_desc
 
-  if (total === null && !description) throw new Error("No Reviews")
+  if (total == null && !description) throw new Error("No Reviews")
 
   return {
     total,

--- a/server/actions/reviews.ts
+++ b/server/actions/reviews.ts
@@ -1,0 +1,58 @@
+import { buildRequestHeaders } from "@/lib/request"
+import { tryCatch } from "@/lib/utils"
+import { RawSteamReviews, SteamReviews } from "@/types/reviews"
+import { unstable_cache } from "next/cache"
+
+const STEAM_REVIEWS_URL = "https://store.steampowered.com/appreviews"
+
+async function fetchSteamReviews(steamId: string): Promise<SteamReviews> {
+  if (!steamId) throw new Error("Invalid Steam Id")
+
+  const url = `${STEAM_REVIEWS_URL}/${steamId}?json=1`
+
+  const { data: response, error } = await tryCatch(
+    fetch(url, {
+      headers: buildRequestHeaders({
+        kind: "api",
+        referer: STEAM_REVIEWS_URL,
+        origin: "https://store.steampowered.com"
+      })
+    })
+  )
+
+  if (error) {
+    throw new Error("Failed to fetch steam reviews from API")
+  }
+
+  if (!response.ok) {
+    const errorText = await response.text()
+    throw new Error(
+      `Steam reviews response error (${response.status}): ${errorText}`
+    )
+  }
+
+  const data = (await response.json()) as RawSteamReviews
+
+  const total = data?.query_summary?.total_reviews
+  const description = data?.query_summary?.review_score_desc
+
+  if (total === null && !description) throw new Error("No Reviews")
+
+  return {
+    total,
+    description
+  }
+}
+
+export const getCachedSteamReviews = async (
+  steamId: string
+): Promise<SteamReviews> => {
+  return unstable_cache(
+    async (steamId: string) => fetchSteamReviews(steamId),
+    [steamId],
+    {
+      tags: [`steam-reviews-${steamId}`],
+      revalidate: 259_200 // 3 days
+    }
+  )(steamId)
+}

--- a/types/reviews.ts
+++ b/types/reviews.ts
@@ -1,0 +1,70 @@
+// Steam Reviews API Sample
+// https://store.steampowered.com/appreviews/2394650?json=1
+
+type ReviewDescription =
+  | "Overwhelmingly Positive"
+  | "Very Positive"
+  | "Positive"
+  | "Mostly Positive"
+  | "Mixed"
+  | "Mostly Negative"
+  | "Negative"
+  | "Overwhelmingly Negative"
+  | "No user reviews"
+
+export interface SteamReviews {
+  total: number
+  description: ReviewDescription
+}
+
+export interface RawSteamReviews {
+  success: number
+  query_summary: {
+    num_reviews: number
+    review_score: number
+    review_score_desc: ReviewDescription
+    total_positive: number
+    total_negative: number
+    total_reviews: number
+  }
+  reviews: RawSteamReview[]
+}
+
+export interface RawSteamReview {
+  recommendationid: string
+  language: string
+  appid: number
+  review: string
+  timestamp_created: number
+  timestamp_updated: number
+  voted_up: boolean
+  votes_up: number
+  votes_funny: number
+  weighted_vote_score: string
+  comment_count: number
+  steam_purchase: boolean
+  received_for_free: boolean
+  refunded: boolean
+  written_during_early_access: boolean
+  primarily_steam_deck: boolean
+  app_release_date: string
+  reactions: {
+    reaction_type: number
+    count: number
+  }[]
+  csgo_disclaimer: boolean
+  author: {
+    steamid: string
+    personaname: string
+    persona_status: string
+    profile_url: string
+    num_games_owned: number
+    num_reviews: number
+    playtime_forever: number
+    playtime_last_two_weeks: number
+    playtime_at_review: number
+    deck_playtime_at_review: number
+    last_played: number
+    avatar: string
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- UI: Added Steam Reviews block to Game component — shows when a Steam ID exists, uses Suspense with a loading fallback, and renders sentiment icons (Laugh/Smile for positive, Meh for mixed, Frown for negative).
- Server: Added server/actions/reviews.ts with fetchSteamReviews and exported getCachedSteamReviews(steamId) which calls the Steam reviews API, validates/parses the response, handles errors, and caches results via next/cache unstable_cache for 3 days with cache tag steam-reviews-${steamId}.
- Types: Added types/reviews.ts — ReviewDescription union plus SteamReviews, RawSteamReviews, and RawSteamReview interfaces modeling the Steam reviews API response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->