### PR TITLE
Service worker implementation

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import Footer from "@/components/layout/Footer"
 import { Header } from "@/components/layout/Header"
 import { GlobalLoader } from "@/components/navigation/GlobalLoader"
 import { NavigationProvider } from "@/components/navigation/NavigationProvider"
+import { ServiceWorkerRegistration } from "@/components/pwa/ServiceWorkerRegistration"
 import { AccentHydrator } from "@/components/theme/AccentHydrator"
 import { Toaster } from "@/components/ui/sonner"
 import { Analytics } from "@vercel/analytics/next"
@@ -58,6 +59,7 @@ export default async function RootLayout({
             ></script> */}
       </head>
       <body>
+        <ServiceWorkerRegistration />
         <AccentHydrator />
         <NavigationProvider>
           <Header />

--- a/components/pwa/ServiceWorkerRegistration.tsx
+++ b/components/pwa/ServiceWorkerRegistration.tsx
@@ -7,10 +7,9 @@ const SERVICE_WORKER_PATH = "/sw.js"
 export function ServiceWorkerRegistration() {
   useEffect(() => {
     const notProductionEnv = process.env.NODE_ENV !== "production"
-    const onServer = typeof window === "undefined"
     const noSWSupport = !("serviceWorker" in navigator)
 
-    if (notProductionEnv || onServer || noSWSupport) return
+    if (notProductionEnv || noSWSupport) return
 
     // If the document is already loaded, we can skip waiting for the load event
     const documentAlreadyLoaded = document.readyState === "complete"

--- a/components/pwa/ServiceWorkerRegistration.tsx
+++ b/components/pwa/ServiceWorkerRegistration.tsx
@@ -1,0 +1,37 @@
+"use client"
+
+import { useEffect } from "react"
+
+const SERVICE_WORKER_PATH = "/sw.js"
+
+export function ServiceWorkerRegistration() {
+  useEffect(() => {
+    const notProductionEnv = process.env.NODE_ENV !== "production"
+    const onServer = typeof window === "undefined"
+    const noSWSupport = !("serviceWorker" in navigator)
+
+    if (notProductionEnv || onServer || noSWSupport) return
+
+    // If the document is already loaded, we can skip waiting for the load event
+    const documentAlreadyLoaded = document.readyState === "complete"
+    if (documentAlreadyLoaded) {
+      void registerServiceWorker()
+      return
+    }
+
+    const onLoad = () => void registerServiceWorker()
+    window.addEventListener("load", onLoad)
+
+    return () => window.removeEventListener("load", onLoad)
+  }, [])
+
+  return null
+}
+
+async function registerServiceWorker() {
+  try {
+    await navigator.serviceWorker.register(SERVICE_WORKER_PATH)
+  } catch (error) {
+    console.warn("Service worker registration failed", error)
+  }
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -33,6 +33,6 @@ export default async function middleware(request: NextRequest) {
 export const config = {
   matcher: [
     // Exclude API, static assets, PWA files, and JSON files (including manifest.json).
-    "/((?!api|_next/static|_next/image|sw.js|favicon.ico|manifest.json|.*\\.json$|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)"
+    "/((?!api|_next/static|_next/image|sw\\.js|favicon.ico|manifest.json|.*\\.json$|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)"
   ]
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,6 +1,8 @@
 import { getToken } from "next-auth/jwt"
 import { NextRequest, NextResponse } from "next/server"
 
+const PUBLIC_ROUTES = ["/", "/launch"]
+
 export default async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl
   const token = await getToken({
@@ -8,7 +10,9 @@ export default async function middleware(request: NextRequest) {
     secret: process.env.NEXTAUTH_SECRET
   })
 
-  if (!token && pathname !== "/") {
+  const isPublicRoute = PUBLIC_ROUTES.includes(pathname)
+
+  if (!token && !isPublicRoute) {
     const url = request.nextUrl.clone()
     url.pathname = "/"
     return NextResponse.redirect(url)

--- a/middleware.ts
+++ b/middleware.ts
@@ -28,7 +28,7 @@ export default async function middleware(request: NextRequest) {
 
 export const config = {
   matcher: [
-    // Exclude API, next static routes, images, favicon, and JSON files (including manifest.json)
-    "/((?!api|_next/static|_next/image|favicon.ico|manifest.json|.*\\.json$|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)"
+    // Exclude API, static assets, PWA files, and JSON files (including manifest.json).
+    "/((?!api|_next/static|_next/image|sw.js|favicon.ico|manifest.json|.*\\.json$|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)"
   ]
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,154 @@
+/*
+  Minimal app-shell service worker.
+
+  Goal:
+  - Make repeat visits boot quickly by caching a tiny "shell" route and static
+    assets used very early in startup.
+
+  Non-goals:
+  - We intentionally do NOT cache authenticated HTML pages or API responses,
+    because those are user/session-specific and can easily become stale/wrong.
+*/
+
+// Bump this string whenever you change SW caching behavior and want to force
+// old caches to be cleaned up on activate.
+const SW_VERSION = "v1"
+
+// We separate shell and generic static assets so strategy changes are easier.
+const APP_SHELL_CACHE = `app-shell-${SW_VERSION}`
+const STATIC_ASSETS_CACHE = `static-assets-${SW_VERSION}`
+
+// "App shell" = the smallest set of assets needed for very fast startup.
+// `/launch` is a light page in this app that immediately routes onward.
+const APP_SHELL_URLS = [
+  "/launch",
+  "/manifest.json",
+  "/favicon/favicon-96x96.png",
+  "/favicon/web-app-manifest-192x192.png",
+  "/favicon/web-app-manifest-512x512.png",
+  "/favicon/apple-touch-icon.png",
+  "/favicon/favicon.svg",
+  "/favicon/favicon.ico"
+]
+
+self.addEventListener("install", (event) => {
+  // waitUntil tells the browser "installation is not done until this resolves".
+  // If this rejects, install fails and the old worker keeps controlling clients.
+  event.waitUntil(
+    caches
+      .open(APP_SHELL_CACHE)
+      // addAll performs fetch + cache in one step for each URL.
+      .then((cache) => cache.addAll(APP_SHELL_URLS))
+      // Ask browser to move this worker to "activating" ASAP.
+      // (Activation still obeys lifecycle constraints.)
+      .then(() => self.skipWaiting())
+  )
+})
+
+self.addEventListener("activate", (event) => {
+  // On activate, remove caches created by older SW versions.
+  // This prevents unbounded cache growth and stale asset usage.
+  event.waitUntil(
+    caches.keys().then((cacheNames) =>
+      Promise.all(
+        cacheNames.map((cacheName) => {
+          if (
+            cacheName !== APP_SHELL_CACHE &&
+            cacheName !== STATIC_ASSETS_CACHE
+          ) {
+            return caches.delete(cacheName)
+          }
+
+          // Keep current cache entries untouched.
+          return Promise.resolve()
+        })
+      )
+    )
+  )
+
+  // Start controlling already-open pages without requiring another navigation.
+  self.clients.claim()
+})
+
+self.addEventListener("fetch", (event) => {
+  const { request } = event
+  const requestUrl = new URL(request.url)
+
+  const isGET = request.method === "GET"
+  const isSameOrigin = requestUrl.origin === self.location.origin
+  const isAPIRoute = requestUrl.pathname.startsWith("/api/")
+
+  if (!isGET || !isSameOrigin || isAPIRoute) return
+
+  // Navigation strategy for app shell:
+  // cache-first gives the fastest possible bootstrap path for `/launch`.
+  const isAppShellRoute =
+    request.mode === "navigate" && requestUrl.pathname === "/launch"
+  if (isAppShellRoute) {
+    event.respondWith(cacheFirstAppShell(request))
+    return
+  }
+
+  // Static assets use stale-while-revalidate:
+  // - immediate cache response if present
+  // - background refresh keeps cache up to date for next visit
+  if (isStaticAsset(requestUrl.pathname)) {
+    event.respondWith(staleWhileRevalidate(request))
+  }
+})
+
+async function cacheFirstAppShell(request) {
+  const cache = await caches.open(APP_SHELL_CACHE)
+
+  // Match by a stable string key so query params on `/launch` do not fragment
+  // cache entries. We intentionally store and read under "/launch".
+  const cachedResponse = await cache.match("/launch")
+
+  if (cachedResponse) {
+    // Fire-and-forget refresh in background to keep cache warm/fresh.
+    // `void` signals we intentionally do not await this Promise.
+    void fetchAndCache(request, cache, "/launch")
+    return cachedResponse
+  }
+
+  // Cold start: no cache available yet, fetch from network and store it.
+  return fetchAndCache(request, cache, "/launch")
+}
+
+async function staleWhileRevalidate(request) {
+  const cache = await caches.open(STATIC_ASSETS_CACHE)
+  const cachedResponse = await cache.match(request)
+
+  // Kick off network fetch immediately; if cache hit exists we still return
+  // cached bytes first, but network response updates cache for future requests.
+  const networkPromise = fetchAndCache(request, cache)
+
+  if (cachedResponse) return cachedResponse
+
+  // Cache miss falls back to network Promise.
+  return networkPromise
+}
+
+async function fetchAndCache(request, cache, cacheKey) {
+  // If network fails, this throws and caller behavior decides fallback.
+  // For stale-while-revalidate with cache hit, user still got cached response.
+  const response = await fetch(request)
+
+  if (response.ok) {
+    // Responses are streams; clone before consuming one copy for CacheStorage.
+    await cache.put(cacheKey ?? request, response.clone())
+  }
+
+  // Non-2xx responses are returned but not cached.
+  return response
+}
+
+function isStaticAsset(pathname) {
+  // Keep this list intentionally narrow to avoid caching dynamic pages.
+  return (
+    pathname.startsWith("/_next/static/") ||
+    pathname.startsWith("/favicon/") ||
+    pathname.startsWith("/pwa/") ||
+    pathname.startsWith("/logos/")
+  )
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -85,7 +85,15 @@ self.addEventListener("fetch", (event) => {
   const isAppShellRoute =
     request.mode === "navigate" && requestUrl.pathname === "/launch"
   if (isAppShellRoute) {
-    event.respondWith(cacheFirstAppShell(request))
+    const task = cacheFirstAppShell(request)
+
+    event.respondWith(task.then(({ response }) => response))
+    event.waitUntil(
+      task
+        .then(({ revalidate }) => revalidate)
+        .catch(() => undefined)
+    )
+
     return
   }
 
@@ -93,7 +101,14 @@ self.addEventListener("fetch", (event) => {
   // - immediate cache response if present
   // - background refresh keeps cache up to date for next visit
   if (isStaticAsset(requestUrl.pathname)) {
-    event.respondWith(staleWhileRevalidate(request))
+    const task = staleWhileRevalidate(request)
+
+    event.respondWith(task.then(({ response }) => response))
+    event.waitUntil(
+      task
+        .then(({ revalidate }) => revalidate)
+        .catch(() => undefined)
+    )
   }
 })
 
@@ -105,14 +120,19 @@ async function cacheFirstAppShell(request) {
   const cachedResponse = await cache.match("/launch")
 
   if (cachedResponse) {
-    // Fire-and-forget refresh in background to keep cache warm/fresh.
-    // `void` signals we intentionally do not await this Promise.
-    void fetchAndCache(request, cache, "/launch")
-    return cachedResponse
+    // When cache hits, return cached response immediately but also revalidate.
+    // The fetch event listener attaches this promise to event.waitUntil().
+    return {
+      response: cachedResponse,
+      revalidate: fetchAndCache(request, cache, "/launch")
+    }
   }
 
   // Cold start: no cache available yet, fetch from network and store it.
-  return fetchAndCache(request, cache, "/launch")
+  return {
+    response: fetchAndCache(request, cache, "/launch"),
+    revalidate: null
+  }
 }
 
 async function staleWhileRevalidate(request) {
@@ -123,10 +143,18 @@ async function staleWhileRevalidate(request) {
   // cached bytes first, but network response updates cache for future requests.
   const networkPromise = fetchAndCache(request, cache)
 
-  if (cachedResponse) return cachedResponse
+  if (cachedResponse) {
+    return {
+      response: cachedResponse,
+      revalidate: networkPromise
+    }
+  }
 
   // Cache miss falls back to network Promise.
-  return networkPromise
+  return {
+    response: networkPromise,
+    revalidate: null
+  }
 }
 
 async function fetchAndCache(request, cache, cacheKey) {

--- a/public/sw.js
+++ b/public/sw.js
@@ -63,10 +63,9 @@ self.addEventListener("activate", (event) => {
         })
       )
     )
+    // Keep activate alive until claim is complete for deterministic takeover.
+    .then(() => self.clients.claim())
   )
-
-  // Start controlling already-open pages without requiring another navigation.
-  self.clients.claim()
 })
 
 self.addEventListener("fetch", (event) => {

--- a/public/sw.js
+++ b/public/sw.js
@@ -22,7 +22,6 @@ const STATIC_ASSETS_CACHE = `static-assets-${SW_VERSION}`
 // `/launch` is a light page in this app that immediately routes onward.
 const APP_SHELL_URLS = [
   "/launch",
-  "/manifest.json",
   "/favicon/favicon-96x96.png",
   "/favicon/web-app-manifest-192x192.png",
   "/favicon/web-app-manifest-512x512.png",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Added service worker registration to the app root by inserting a new client component ServiceWorkerRegistration into app/layout.tsx.
- Added components/pwa/ServiceWorkerRegistration.tsx — a client-only React component that registers the service worker only in production when navigator.serviceWorker is available; registers immediately if document is already loaded or on window "load", with error handling; component renders null.
- Implemented a new public service worker at public/sw.js using an app-shell strategy for the /launch route and stale-while-revalidate caching for selected static assets (/_next/static, /favicon, /pwa, /logos). Includes versioned caches, install/activate lifecycle handling, fetch handlers, fetch-and-cache helpers, and explicit avoidance of caching authenticated pages and API routes.
- Updated middleware.ts: introduced PUBLIC_ROUTES (["/", "/launch"]) and changed auth redirect logic to skip redirects for public routes; expanded Next.js matcher negative lookahead to exclude sw.js (and other static/PWA files) from middleware handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->