### PR TITLE
Steam reviews page

### DIFF
--- a/app/reviews/[steamId]/page.tsx
+++ b/app/reviews/[steamId]/page.tsx
@@ -31,6 +31,7 @@ export default async function SteamReviewsPage({ params }: Props) {
     "CA",
     "app_review_hash"
   )
+  if (!steamReviewsUrl) notFound()
 
   return (
     <div className="custom-slide-up-fade-in">
@@ -39,7 +40,7 @@ export default async function SteamReviewsPage({ params }: Props) {
         <Star className="mr-1 size-9 fill-[#fbc113] text-[#fbc113]" />
       </div>
       <a
-        href={steamReviewsUrl!}
+        href={steamReviewsUrl}
         target="_blank"
         rel="noopener noreferrer"
         className="mt-1 flex w-fit items-center gap-2 px-2 text-lg text-muted-foreground hover:opacity-90"

--- a/app/reviews/[steamId]/page.tsx
+++ b/app/reviews/[steamId]/page.tsx
@@ -1,0 +1,79 @@
+import { ExpandableText } from "@/components/ui/expandable-text"
+import { cn, formatReleaseDate, tryCatch } from "@/lib/utils"
+import { getCachedSteamReviews } from "@/server/actions/reviews"
+import { SteamReview } from "@/types/reviews"
+import { Check, Star, X } from "lucide-react"
+import { notFound } from "next/navigation"
+
+interface Props {
+  params: Promise<{ steamId: string }>
+}
+
+export default async function SteamReviewsPage({ params }: Props) {
+  const { steamId } = await params
+  if (!steamId) notFound()
+
+  const { data, error } = await tryCatch(getCachedSteamReviews(steamId))
+  if (error) notFound()
+
+  const starRatio =
+    Math.round((Math.abs(data.positive / data.total) * 100) / 2) / 10
+
+  if (Number.isNaN(starRatio)) {
+    console.error("Error calculating Steam star ratio:", data)
+    return null
+  }
+
+  return (
+    <div className="custom-slide-up-fade-in">
+      <div className="flex items-baseline gap-3">
+        <h2 className="text-7xl font-bold">{starRatio}</h2>
+        <Star className="mr-1 size-9 fill-[#fbc113] text-[#fbc113]" />
+      </div>
+      <p className="mt-1 pl-2 text-lg text-muted-foreground">
+        {data.total} reviews
+      </p>
+
+      <div className="mt-6 space-y-4">
+        {data.reviews.map((review, index) => (
+          <Review key={index} {...review} />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function Review(review: SteamReview) {
+  return (
+    <div
+      className={cn(
+        "rounded-[2rem] bg-card px-5 py-[18px] shadow-sm",
+        review.recommended ? "shadow-green-600" : "shadow-red-600"
+      )}
+    >
+      <header className="flex items-center gap-3">
+        <div
+          className={cn(
+            "rounded-full p-2 text-accent-foreground",
+            review.recommended ? "bg-green-600" : "bg-red-600"
+          )}
+        >
+          {review.recommended ? <Check /> : <X />}
+        </div>
+        <div>
+          <p className="font-semibold">{review.username}</p>
+          {review.date && (
+            <p className="mt-[1px] text-xs text-muted-foreground">
+              {formatReleaseDate(review.date)}
+            </p>
+          )}
+        </div>
+      </header>
+      <ExpandableText
+        text={review.message}
+        className="mt-4 text-sm text-muted-foreground"
+        lineClamp={6}
+      />
+    </div>
+  )
+}

--- a/app/reviews/[steamId]/page.tsx
+++ b/app/reviews/[steamId]/page.tsx
@@ -1,8 +1,10 @@
+import { Button } from "@/components/ui/button"
 import { ExpandableText } from "@/components/ui/expandable-text"
+import { buildSteamStorePageUrl } from "@/lib/igdb-store-links"
 import { cn, formatReleaseDate, tryCatch } from "@/lib/utils"
 import { getCachedSteamReviews } from "@/server/actions/reviews"
 import { SteamReview } from "@/types/reviews"
-import { Check, Star, X } from "lucide-react"
+import { Check, ExternalLink, Star, X } from "lucide-react"
 import { notFound } from "next/navigation"
 
 interface Props {
@@ -24,15 +26,27 @@ export default async function SteamReviewsPage({ params }: Props) {
     return null
   }
 
+  const steamReviewsUrl = buildSteamStorePageUrl(
+    steamId,
+    "CA",
+    "app_review_hash"
+  )
+
   return (
     <div className="custom-slide-up-fade-in">
       <div className="flex items-baseline gap-3">
         <h2 className="text-7xl font-bold">{starRatio}</h2>
         <Star className="mr-1 size-9 fill-[#fbc113] text-[#fbc113]" />
       </div>
-      <p className="mt-1 pl-2 text-lg text-muted-foreground">
-        {data.total} reviews
-      </p>
+      <a
+        href={steamReviewsUrl!}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="mt-1 flex w-fit items-center gap-2 px-2 text-lg text-muted-foreground hover:opacity-90"
+      >
+        <p>{data.total} reviews</p>
+        <ExternalLink className="size-4" />
+      </a>
 
       <div className="mt-6 space-y-4">
         {data.reviews.map((review, index) => (

--- a/app/reviews/[steamId]/page.tsx
+++ b/app/reviews/[steamId]/page.tsx
@@ -4,7 +4,7 @@ import { buildSteamStorePageUrl } from "@/lib/igdb-store-links"
 import { cn, formatReleaseDate, tryCatch } from "@/lib/utils"
 import { getCachedSteamReviews } from "@/server/actions/reviews"
 import { SteamReview } from "@/types/reviews"
-import { Check, ExternalLink, Star, X } from "lucide-react"
+import { Check, ExternalLink, Info, Star, X } from "lucide-react"
 import { notFound } from "next/navigation"
 
 interface Props {
@@ -52,6 +52,17 @@ export default async function SteamReviewsPage({ params }: Props) {
         {data.reviews.map((review, index) => (
           <Review key={index} {...review} />
         ))}
+      </div>
+      <div className="mt-6 flex gap-2 rounded-2xl px-2 text-muted-foreground">
+        <Info className="mt-[3px] size-[18px]" />
+        <p className="flex-1 text-sm">
+          Only 20 reviews are being shown. Visit the official steam page to{" "}
+          <a href={steamReviewsUrl!} target="_blank" rel="noopener noreferrer">
+            view all reviews{" "}
+            <ExternalLink className="-mt-[2px] ml-[1px] inline size-[14px]" />
+          </a>
+          .
+        </p>
       </div>
     </div>
   )

--- a/components/game/Completed/MoveToCompleted.tsx
+++ b/components/game/Completed/MoveToCompleted.tsx
@@ -1,9 +1,14 @@
 "use client"
 
-import { saveGame } from "@/server/actions/game"
-import { GameCategory, GameInput, GameOutput } from "@/types"
-import { revalidateTag } from "next/cache"
 import { useRouter } from "@/components/navigation"
+import {
+  buildNintendoStoreUrl,
+  buildPlayStationStoreUrl,
+  buildSteamStoreUrl
+} from "@/lib/igdb-store-links"
+import { saveGame } from "@/server/actions/game"
+import { unlinkPriceFromGame } from "@/server/actions/price"
+import { GameCategory, GameInput, GameOutput } from "@/types"
 import { useState } from "react"
 import { toast } from "sonner"
 import { Button } from "../../ui/button"
@@ -11,18 +16,11 @@ import {
   Drawer,
   DrawerClose,
   DrawerContent,
-  DrawerDescription,
   DrawerFooter,
   DrawerHeader,
   DrawerTitle,
   DrawerTrigger
 } from "../../ui/drawer"
-import {
-  buildNintendoStoreUrl,
-  buildPlayStationStoreUrl,
-  buildSteamStoreUrl
-} from "@/lib/igdb-store-links"
-import { unlinkPriceFromGame } from "@/server/actions/price"
 
 interface Props {
   game: GameOutput

--- a/components/game/Game.tsx
+++ b/components/game/Game.tsx
@@ -1,7 +1,4 @@
-import {
-  buildIGDBImageUrl,
-  buildSteamStorePageUrl
-} from "@/lib/igdb-store-links"
+import { buildIGDBImageUrl } from "@/lib/igdb-store-links"
 import { formatReleaseDate, tryCatch } from "@/lib/utils"
 import { getCachedSteamReviews } from "@/server/actions/reviews"
 import {
@@ -11,6 +8,7 @@ import {
 import { ExternalLink, LoaderCircle, Star } from "lucide-react"
 import Image from "next/image"
 import { Suspense } from "react"
+import { Link } from "../navigation"
 import NintendoPrice from "../pricing/NintendoPrice"
 import PlaystationPrice from "../pricing/PlaystationPrice"
 import SteamPrice from "../pricing/SteamPrice"
@@ -384,20 +382,16 @@ async function SteamReviews({ steamId }: { steamId: string }) {
     return null
   }
 
-  const storeUrl = buildSteamStorePageUrl(steamId) || ""
-
   return (
     <div className="flex items-center text-sm">
       <span className="mr-2 font-bold">•</span>
-      <a
-        href={storeUrl}
-        target="_blank"
-        rel="noopener noreferrer"
+      <Link
+        href={`/reviews/${steamId}`}
         className="flex items-center text-sm hover:opacity-90"
       >
         <Star className="mr-1 h-4 w-4 fill-[#fbc113] text-[#fbc113]" />
         <span>{starRatio}</span>
-      </a>
+      </Link>
     </div>
   )
 }

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -28,6 +28,9 @@ function resolveHeader(pathname: string): ReactNode {
   const searchHeader = resolveSearchHeader(pathname)
   if (searchHeader) return searchHeader
 
+  const reviewsHeader = resolveReviewsHeader(pathname)
+  if (reviewsHeader) return reviewsHeader
+
   return <DefaultHeader />
 }
 
@@ -66,6 +69,15 @@ function resolveSearchHeader(pathname: string): ReactNode | null {
   if (segments.length >= 3) {
     return <DefaultHeader />
   }
+
+  return null
+}
+
+function resolveReviewsHeader(pathname: string): ReactNode | null {
+  const segments = splitPathSegments(pathname)
+  if (segments[0] !== "reviews") return null
+
+  if (segments.length === 2) return <ReviewsHeader />
 
   return null
 }
@@ -109,6 +121,15 @@ function CompletedHeader() {
     <>
       <BackButton />
       <h1 className="text-xl font-bold">Completed</h1>
+    </>
+  )
+}
+
+function ReviewsHeader() {
+  return (
+    <>
+      <BackButton />
+      <h1 className="text-xl font-bold">Steam Reviews</h1>
     </>
   )
 }

--- a/lib/igdb-store-links.ts
+++ b/lib/igdb-store-links.ts
@@ -91,14 +91,15 @@ export function buildSteamStoreUrl(
  */
 export function buildSteamStorePageUrl(
   urlSegment: string,
-  country: Country = "CA"
+  country: Country = "CA",
+  hash?: string
 ): string | null {
   if (!urlSegment) return null
 
   const appId = extractSteamAppId(urlSegment)
   if (!appId) return null
 
-  return `https://store.steampowered.com/app/${appId}/?cc=${country.toLowerCase()}&l=en`
+  return `https://store.steampowered.com/app/${appId}/?cc=${country.toLowerCase()}&l=en${hash ? `#${hash}` : ""}`
 }
 
 function extractSteamAppId(urlSegment: string): string | null {

--- a/server/actions/reviews.ts
+++ b/server/actions/reviews.ts
@@ -36,7 +36,7 @@ async function fetchSteamReviews(steamId: string): Promise<SteamReviews> {
   const total = data?.query_summary?.total_reviews
   const positive = data?.query_summary?.total_positive
   const description = data?.query_summary?.review_score_desc
-  const reviews = data?.reviews.map((review: RawSteamReview) => ({
+  const reviews = (data?.reviews ?? []).map((review: RawSteamReview) => ({
     message: review.review,
     recommended: review.voted_up,
     username: review.author?.personaname,

--- a/server/actions/reviews.ts
+++ b/server/actions/reviews.ts
@@ -1,6 +1,6 @@
 import { buildRequestHeaders } from "@/lib/request"
 import { tryCatch } from "@/lib/utils"
-import { RawSteamReviews, SteamReviews } from "@/types/reviews"
+import { RawSteamReview, RawSteamReviews, SteamReviews } from "@/types/reviews"
 import { unstable_cache } from "next/cache"
 
 const STEAM_REVIEWS_URL = "https://store.steampowered.com/appreviews"
@@ -36,13 +36,20 @@ async function fetchSteamReviews(steamId: string): Promise<SteamReviews> {
   const total = data?.query_summary?.total_reviews
   const positive = data?.query_summary?.total_positive
   const description = data?.query_summary?.review_score_desc
+  const reviews = data?.reviews.map((review: RawSteamReview) => ({
+    message: review.review,
+    recommended: review.voted_up,
+    username: review.author?.personaname,
+    date: review.timestamp_created
+  }))
 
   if (total == null || !description) throw new Error("No Reviews")
 
   return {
     total,
     positive,
-    description
+    description,
+    reviews
   }
 }
 

--- a/types/reviews.ts
+++ b/types/reviews.ts
@@ -16,6 +16,14 @@ export interface SteamReviews {
   total: number
   positive: number
   description: ReviewDescription
+  reviews: SteamReview[]
+}
+
+export interface SteamReview {
+  message: string
+  recommended: boolean
+  username?: string
+  date?: number
 }
 
 export interface RawSteamReviews {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Adds new server-rendered page at /reviews/[steamId] that validates params, fetches cached Steam reviews, calculates a star ratio, and renders star rating, link to Steam reviews, and a list of individual review cards (recommendation badge, username, formatted date, and expandable review text)
- Introduces a nested Review component and uses utility/components (ExpandableText, Star, Check, X, ExternalLink, Button, cn, formatReleaseDate) for UI and styling
- Adds a new SteamReview type and extends SteamReviews to include a reviews array; server action now maps RawSteamReview into SteamReview objects (message, recommended, username, date)
- Updates buildSteamStorePageUrl to accept an optional hash parameter to append URL fragments
- Refactors Game component to use an internal Link to /reviews/{steamId} instead of linking directly to the Steam store
- Adds ReviewsHeader and resolves it in Header.tsx to show a back button and "Steam Reviews" title for review routes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->