### PR TITLE
Image caching

### DIFF
--- a/components/game/Game.tsx
+++ b/components/game/Game.tsx
@@ -66,9 +66,9 @@ export function Game({
             alt={name || "Game cover"}
             width={190}
             height={253}
-            sizes="190px"
             priority
             fetchPriority="high"
+            unoptimized
           />
         </div>
         <h1 className="mb-1 line-clamp-2 max-w-[85%] text-2xl font-bold">

--- a/components/game/Game.tsx
+++ b/components/game/Game.tsx
@@ -169,53 +169,43 @@ export function Game({
         <div className="mt-8 flex flex-col">
           <label className="mb-3 text-lg font-bold">Media</label>
           <div
-            className="hide-scrollbar -mx-4 snap-x snap-mandatory overflow-x-auto scroll-smooth"
+            className="hide-scrollbar -mx-4 flex snap-x snap-mandatory gap-[6px] overflow-x-auto scroll-smooth"
             data-scroll-restore-id="media"
             tabIndex={0}
             role="region"
             aria-label="media"
           >
-            <div className="flex">
-              {hasVideos &&
-                igdbVideoIds.map((videoId, index) => {
-                  if (index >= 3) return null
-                  return (
-                    <div
-                      key={videoId}
-                      // 356px = 348px (image) + 8px (2x 4px horizontal padding)
-                      // 368px = 348px (image) + 4px (horizontal padding) + 16px (first or last element, 16px)
-                      className="w-[95%] max-w-[356px] shrink-0 snap-center px-1 first:max-w-[368px] first:pl-4 last:max-w-[368px] last:pr-4"
-                    >
-                      <YoutubeVideo
-                        videoId={videoId}
-                        width={348}
-                        height={196}
-                      />
-                    </div>
-                  )
-                })}
-              {hasScreenshots &&
-                igdbScreenshotIds.map((screenshotId, index) => {
-                  if (index >= 6) return null
-                  return (
-                    <div
-                      key={screenshotId}
-                      // 356px = 348px (image) + 8px (2x 4px horizontal padding)
-                      // 368px = 348px (image) + 4px (horizontal padding) + 16px (first or last element, 16px)
-                      className="w-[95%] max-w-[356px] shrink-0 snap-center px-1 first:max-w-[368px] first:pl-4 last:max-w-[368px] last:pr-4"
-                    >
-                      <Image
-                        src={buildIGDBImageUrl(screenshotId || "")}
-                        alt={name || "Game cover"}
-                        width={348}
-                        height={196}
-                        className="overflow-hidden rounded-2xl"
-                        unoptimized
-                      />
-                    </div>
-                  )
-                })}
-            </div>
+            {hasVideos &&
+              igdbVideoIds.map((videoId, index) => {
+                if (index >= 3) return null
+                return (
+                  <div
+                    key={videoId}
+                    className="w-[calc(100%-32px)] shrink-0 snap-center first:ml-4 last:mr-4"
+                  >
+                    <YoutubeVideo videoId={videoId} width={358} height={201} />
+                  </div>
+                )
+              })}
+            {hasScreenshots &&
+              igdbScreenshotIds.map((screenshotId, index) => {
+                if (index >= 6) return null
+                return (
+                  <div
+                    key={screenshotId}
+                    className="w-[calc(100%-32px)] shrink-0 snap-center first:ml-4 last:mr-4"
+                  >
+                    <Image
+                      src={buildIGDBImageUrl(screenshotId || "")}
+                      alt={name || "Game cover"}
+                      width={358}
+                      height={201}
+                      className="overflow-hidden rounded-2xl"
+                      unoptimized
+                    />
+                  </div>
+                )
+              })}
           </div>
         </div>
       )}

--- a/components/game/YoutubeVideo.tsx
+++ b/components/game/YoutubeVideo.tsx
@@ -16,8 +16,8 @@ type Props = {
 
 export function YoutubeVideo({
   videoId,
-  width = 332,
-  height = 187,
+  width = 358,
+  height = 201,
   className
 }: Props) {
   const encodedId = encodeURIComponent(videoId)

--- a/next.config.ts
+++ b/next.config.ts
@@ -5,7 +5,7 @@ const nextConfig: NextConfig = {
     APP_VERSION: process.env.npm_package_version
   },
   images: {
-    minimumCacheTTL: 10_368_000, // 4 months
+    minimumCacheTTL: 2_592_000, // 30 days
     remotePatterns: [
       {
         protocol: "https",

--- a/public/sw.js
+++ b/public/sw.js
@@ -17,14 +17,14 @@ const SW_VERSION = "0.3.69"
 
 // Keep one small cache dedicated to startup-critical responses.
 const BOOT_CACHE = `boot-cache-${SW_VERSION}`
-// Store remote IGDB artwork separately from boot assets so image churn does
-// not evict the tiny shell cache used for fast startup.
-const IGDB_IMAGE_CACHE = "igdb-image-cache-v1"
+// Store remote artwork separately from boot assets so image churn does not
+// evict the tiny shell cache used for fast startup.
+const REMOTE_IMAGE_CACHE = "remote-image-cache-v1"
 // CacheStorage cannot attach custom metadata to entries, so keep TTL metadata
 // in a parallel cache keyed by the same request URL.
-const IGDB_IMAGE_META_CACHE = "igdb-image-meta-v1"
-// IGDB image URLs are content-addressed enough to tolerate long-lived reuse.
-const IGDB_IMAGE_TTL_MS = 2_592_000_000 // 30 days
+const REMOTE_IMAGE_META_CACHE = "remote-image-meta-v1"
+// These remote image URLs are stable enough to tolerate long-lived reuse.
+const REMOTE_IMAGE_TTL_MS = 2_592_000_000 // 30 days
 
 // "App shell" = the smallest set of assets needed for very fast startup.
 // `/launch` is a light page in this app that immediately routes onward.
@@ -48,7 +48,7 @@ self.addEventListener("install", (event) => {
 
 self.addEventListener("activate", (event) => {
   // On activate, rotate versioned boot caches while preserving long-lived
-  // IGDB image caches across releases.
+  // remote image caches across releases.
   event.waitUntil(
     caches
       .keys()
@@ -77,14 +77,34 @@ self.addEventListener("fetch", (event) => {
 
   if (!isGET) return
 
-  // IGDB images are a separate cross-origin cache path. Keep them out of the
+  // Remote artwork is a separate cross-origin cache path. Keep it out of the
   // boot cache and allow stale entries to cover offline/error cases while
   // refreshing from network whenever the TTL has expired.
   const isIGDBImageRequest = requestUrl.href.startsWith(
     "https://images.igdb.com/igdb/image/upload/"
   )
   if (isIGDBImageRequest) {
-    event.respondWith(serveIGDBImage(request))
+    event.respondWith(
+      serveRemoteImage(request, {
+        cacheName: REMOTE_IMAGE_CACHE,
+        metaCacheName: REMOTE_IMAGE_META_CACHE,
+        ttlMs: REMOTE_IMAGE_TTL_MS
+      })
+    )
+    return
+  }
+
+  const isYouTubeImageRequest = requestUrl.href.startsWith(
+    "https://i.ytimg.com/vi/"
+  )
+  if (isYouTubeImageRequest) {
+    event.respondWith(
+      serveRemoteImage(request, {
+        cacheName: REMOTE_IMAGE_CACHE,
+        metaCacheName: REMOTE_IMAGE_META_CACHE,
+        ttlMs: REMOTE_IMAGE_TTL_MS
+      })
+    )
     return
   }
 
@@ -137,9 +157,9 @@ async function fetchAndCache(request, cache, cacheKey) {
   return response
 }
 
-async function serveIGDBImage(request) {
-  const imageCache = await caches.open(IGDB_IMAGE_CACHE)
-  const metadataCache = await caches.open(IGDB_IMAGE_META_CACHE)
+async function serveRemoteImage(request, { cacheName, metaCacheName, ttlMs }) {
+  const imageCache = await caches.open(cacheName)
+  const metadataCache = await caches.open(metaCacheName)
   const cacheKey = request
   const metaCacheKey = request.url
 
@@ -148,7 +168,7 @@ async function serveIGDBImage(request) {
     readCachedAt(metadataCache, metaCacheKey)
   ])
 
-  const isExpired = (cachedAt) => Date.now() - cachedAt >= IGDB_IMAGE_TTL_MS
+  const isExpired = (cachedAt) => Date.now() - cachedAt >= ttlMs
   const isCacheValid = cachedAt && !isExpired(cachedAt)
 
   if (cachedResponse && isCacheValid) return cachedResponse
@@ -215,12 +235,12 @@ function shouldDeleteCache(cacheName) {
     return cacheName !== BOOT_CACHE
   }
 
-  if (cacheName.startsWith("igdb-image-cache-")) {
-    return cacheName !== IGDB_IMAGE_CACHE
+  if (cacheName.startsWith("remote-image-cache-")) {
+    return cacheName !== REMOTE_IMAGE_CACHE
   }
 
-  if (cacheName.startsWith("igdb-image-meta-")) {
-    return cacheName !== IGDB_IMAGE_META_CACHE
+  if (cacheName.startsWith("remote-image-meta-")) {
+    return cacheName !== REMOTE_IMAGE_META_CACHE
   }
 
   return false

--- a/public/sw.js
+++ b/public/sw.js
@@ -17,6 +17,14 @@ const SW_VERSION = "0.3.69"
 
 // Keep one small cache dedicated to startup-critical responses.
 const BOOT_CACHE = `boot-cache-${SW_VERSION}`
+// Store remote IGDB artwork separately from boot assets so image churn does
+// not evict the tiny shell cache used for fast startup.
+const IGDB_IMAGE_CACHE = "igdb-image-cache-v1"
+// CacheStorage cannot attach custom metadata to entries, so keep TTL metadata
+// in a parallel cache keyed by the same request URL.
+const IGDB_IMAGE_META_CACHE = "igdb-image-meta-v1"
+// IGDB image URLs are content-addressed enough to tolerate long-lived reuse.
+const IGDB_IMAGE_TTL_MS = 2_592_000_000 // 30 days
 
 // "App shell" = the smallest set of assets needed for very fast startup.
 // `/launch` is a light page in this app that immediately routes onward.
@@ -39,15 +47,15 @@ self.addEventListener("install", (event) => {
 })
 
 self.addEventListener("activate", (event) => {
-  // On activate, remove caches created by older SW versions.
-  // This prevents unbounded cache growth and stale asset usage.
+  // On activate, rotate versioned boot caches while preserving long-lived
+  // IGDB image caches across releases.
   event.waitUntil(
     caches
       .keys()
       .then((cacheNames) =>
         Promise.all(
           cacheNames.map((cacheName) => {
-            if (cacheName !== BOOT_CACHE) {
+            if (shouldDeleteCache(cacheName)) {
               return caches.delete(cacheName)
             }
 
@@ -66,10 +74,24 @@ self.addEventListener("fetch", (event) => {
   const requestUrl = new URL(request.url)
 
   const isGET = request.method === "GET"
+
+  if (!isGET) return
+
+  // IGDB images are a separate cross-origin cache path. Keep them out of the
+  // boot cache and allow stale entries to cover offline/error cases while
+  // refreshing from network whenever the TTL has expired.
+  const isIGDBImageRequest = requestUrl.href.startsWith(
+    "https://images.igdb.com/igdb/image/upload/"
+  )
+  if (isIGDBImageRequest) {
+    event.respondWith(serveIGDBImage(request))
+    return
+  }
+
   const isSameOrigin = requestUrl.origin === self.location.origin
   const isAPIRoute = requestUrl.pathname.startsWith("/api/")
 
-  if (!isGET || !isSameOrigin || isAPIRoute) return
+  if (!isSameOrigin || isAPIRoute) return
 
   // Navigation strategy for app shell:
   // cache-first gives the fastest possible bootstrap path for `/launch`.
@@ -115,9 +137,91 @@ async function fetchAndCache(request, cache, cacheKey) {
   return response
 }
 
+async function serveIGDBImage(request) {
+  const imageCache = await caches.open(IGDB_IMAGE_CACHE)
+  const metadataCache = await caches.open(IGDB_IMAGE_META_CACHE)
+  const cacheKey = request
+  const metaCacheKey = request.url
+
+  const [cachedResponse, cachedAt] = await Promise.all([
+    imageCache.match(cacheKey),
+    readCachedAt(metadataCache, metaCacheKey)
+  ])
+
+  const isExpired = (cachedAt) => Date.now() - cachedAt >= IGDB_IMAGE_TTL_MS
+  const isCacheValid = cachedAt && !isExpired(cachedAt)
+
+  if (cachedResponse && isCacheValid) return cachedResponse
+
+  try {
+    const response = await fetch(request)
+
+    const isCachable = response.ok || response.type === "opaque"
+
+    if (isCachable) {
+      await Promise.all([
+        imageCache.put(cacheKey, response.clone()),
+        writeCachedAt(metadataCache, metaCacheKey, Date.now())
+      ])
+    }
+
+    return response
+  } catch (error) {
+    // Return stale cache if new response fails
+    if (cachedResponse) return cachedResponse
+
+    throw error
+  }
+}
+
+async function readCachedAt(cache, cacheKey) {
+  const response = await cache.match(cacheKey)
+
+  if (!response) return null
+
+  try {
+    // Treat malformed metadata as a miss so the image is refreshed normally.
+    const data = await response.json()
+    const cachedAt = Number(data?.cachedAt)
+    return Number.isFinite(cachedAt) ? cachedAt : null
+  } catch {
+    return null
+  }
+}
+
+async function writeCachedAt(cache, cacheKey, cachedAt) {
+  // Store only the timestamp we need for TTL checks; image bytes live in the
+  // separate artwork cache.
+  const response = new Response(JSON.stringify({ cachedAt }), {
+    headers: {
+      "content-type": "application/json"
+    }
+  })
+
+  await cache.put(cacheKey, response)
+}
+
 function isBootStaticAsset(pathname) {
   // Keep this list intentionally narrow. `/_next/static/` contains the
   // hashed JS/CSS chunks needed to hydrate and navigate quickly on repeat
   // launches, without pulling dynamic HTML or user-specific data into SW.
   return pathname.startsWith("/_next/static/")
+}
+
+function shouldDeleteCache(cacheName) {
+  // Rotate versioned caches within each namespace, but leave unrelated caches
+  // untouched in case the browser stores entries from other features/origins.
+  if (cacheName.startsWith("boot-cache-")) {
+    return cacheName !== BOOT_CACHE
+  }
+
+  if (cacheName.startsWith("igdb-image-cache-")) {
+    return cacheName !== IGDB_IMAGE_CACHE
+  }
+
+  if (cacheName.startsWith("igdb-image-meta-")) {
+    return cacheName !== IGDB_IMAGE_META_CACHE
+  }
+
+  return false
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Reduced `next.config.ts` image cache TTL from 4 months to 30 days
- Enhanced service worker to intercept and cache remote images (IGDB and YouTube URLs) with 30-day TTL and stale-on-error fallback behavior
- Added TTL metadata tracking in service worker to manage image cache freshness
- Refactored Game component media scroller layout: removed nested wrapper, unified gap-based spacing, and updated media item dimensions
- Updated YoutubeVideo and screenshot image default dimensions to 358x201 pixels

<!-- end of auto-generated comment: release notes by coderabbit.ai -->